### PR TITLE
Review serializer & Updated create user

### DIFF
--- a/digestapi/views/books.py
+++ b/digestapi/views/books.py
@@ -1,8 +1,10 @@
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework import serializers
-from digestapi.models import Book
+from digestapi.models import Book, Review
 from .categories import CategorySerializer
+from .reviews import ReviewSerializer
+from django.contrib.auth.models import User
 
 
 class BookSerializer(serializers.ModelSerializer):
@@ -10,6 +12,7 @@ class BookSerializer(serializers.ModelSerializer):
     # with expanded related resource. By default, this would
     # be a list of integers (e.g. [2, 4, 9]).
     categories = CategorySerializer(many=True)
+    reviews = ReviewSerializer(many=True)
 
     # Declare that an ad-hoc property should be included in JSON
     is_owner = serializers.SerializerMethodField()
@@ -21,7 +24,7 @@ class BookSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Book
-        fields = ['id', 'title', 'author', 'isbn_number', 'cover_image', 'is_owner', 'categories']
+        fields = ['id', 'title', 'author', 'isbn_number', 'cover_image', 'is_owner', 'categories', 'reviews']
 
 
 class BookViewSet(viewsets.ViewSet):

--- a/digestapi/views/reviews.py
+++ b/digestapi/views/reviews.py
@@ -3,13 +3,21 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from digestapi.models import Review, Book
 from rest_framework import permissions
+from django.contrib.auth.models import User
+
+class UserReviewSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = User
+        fields = ['first_name', 'last_name',]
 
 class ReviewSerializer(serializers.ModelSerializer):
     is_owner = serializers.SerializerMethodField()
+    user = UserReviewSerializer(many=False)
 
     class Meta:
         model = Review
-        fields = ['id', 'book', 'user', 'rating', 'comment', 'date', 'is_owner']
+        fields = ['id', 'book', 'user', 'rating', 'comment', 'date', 'is_owner',]
         read_only_fields = ['user']
 
     def get_is_owner(self, obj):

--- a/digestapi/views/users.py
+++ b/digestapi/views/users.py
@@ -11,7 +11,7 @@ from django.contrib.auth import authenticate
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'username', 'password']
+        fields = ['id', 'username', 'password', 'first_name', 'last_name']
         extra_kwargs = {'password': {'write_only': True}}
 
 
@@ -25,7 +25,9 @@ class UserViewSet(viewsets.ViewSet):
         if serializer.is_valid():
             user = User.objects.create_user(
                 username=serializer.validated_data['username'],
-                password=serializer.validated_data['password']
+                password=serializer.validated_data['password'],
+                first_name=serializer.validated_data['first_name'],
+                last_name=serializer.validated_data['last_name']
             )
             token, created = Token.objects.get_or_create(user=user)
             return Response({"token": token.key}, status=status.HTTP_201_CREATED)

--- a/digestapi/views/users.py
+++ b/digestapi/views/users.py
@@ -11,7 +11,7 @@ from django.contrib.auth import authenticate
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'username', 'password', 'first_name', 'last_name']
+        fields = ['id', 'username', 'password', 'first_name', 'last_name',]
         extra_kwargs = {'password': {'write_only': True}}
 
 


### PR DESCRIPTION
# Added reviews and reviewer's name to book requests
## Steps to Accomplish
- Added `reviews` to fields in `BookSerializer` in `books.py`
- Updated the `user` field in 'ReviewSerializer` in `reviews.py` to include an object that has the users first and last name
- Updated the `UserSerializer` in `users.py` to include first_name and last_name
- Added first_name and last_name to user object creation in the `UserViewSet`
## Steps to Test
- Pull down the `review-serializer` branch associated with this PR
- Start/Restart your debugger/JSON-Server
- Open your preferred API testing software
- Prior to submitting a request, add an Authentication Header with the value of "Token x", use the token (x) associated with your login.
- Submit a GET request to 'http://localhost:8000/books'
- Verify that in the response that the book object contains `reviews` and `user` in `reviews` contains `first_name` and `last_name`